### PR TITLE
Minor changes

### DIFF
--- a/Application/Program.cs
+++ b/Application/Program.cs
@@ -27,6 +27,8 @@ Commands are:
 
             using (var db = new BusContext(options))
             {
+                db.Database.Migrate();
+
                 while (true)
                 {
                     Console.Write("Command | ");

--- a/Infrastructure/BusContext.cs
+++ b/Infrastructure/BusContext.cs
@@ -10,9 +10,6 @@ namespace Infrastructure
         public DbSet<BusRouteMemento> BusRoutes { get; set; }
         public DbSet<ScheduledServiceMemento> Services { get; set; }
 
-        public BusContext()
-        { }
-
         public BusContext(DbContextOptions<BusContext> options) : base(options) { }
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/Infrastructure/BusContext.cs
+++ b/Infrastructure/BusContext.cs
@@ -19,10 +19,5 @@ namespace Infrastructure
         {
             builder.ApplyConfiguration(new BusesConfiguration());
         }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(@"Server=(LocalDB)\MSSQLLocalDB;Database=BusRoutes;Trusted_Connection=True;");
-        }
     }
 }

--- a/Infrastructure/BusContextDesignTimeFactory.cs
+++ b/Infrastructure/BusContextDesignTimeFactory.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Infrastructure
+{
+    public class BusContextDesignTimeFactory : IDesignTimeDbContextFactory<BusContext>
+    {
+        public BusContext CreateDbContext(string[] args)
+        {
+            var options = new DbContextOptionsBuilder<BusContext>()
+                .UseSqlServer(@"Server=(LocalDB)\MSSQLLocalDB;Database=BusRoutes;Trusted_Connection=True;")
+                .Options;
+
+            return new BusContext(options);
+        }
+    }
+}


### PR DESCRIPTION
Hi Richard 👋

Thanks for the blog post, really informative.
I have a couple of changes that I thought I'd push.

First, running the migrations and potentially creating the database automatically when the app starts allows people to _F5_ and see it running quickly.

Also, having configuration in the `OnConfiguring` method of the `DbContext` can overwrite the `DbContextOptions` passed into the constructor as mentioned at the bottom of [this paragraph](https://docs.microsoft.com/en-us/ef/core/miscellaneous/configuring-dbcontext#configuring-dbcontextoptions). To still be able to add migrations, you can create a design-time factory that the EF toold will discover and use when you use `dotnet ef`. This is documented [here](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dbcontext-creation#from-a-design-time-factory).

Thanks again!